### PR TITLE
Include Products.CMFCore in configure.zcml

### DIFF
--- a/src/gisweb/iol/configure.zcml
+++ b/src/gisweb/iol/configure.zcml
@@ -7,6 +7,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="gisweb.iol">
 
+  <include package="Products.CMFCore" />
   <include package="Products.CMFPlacefulWorkflow" />
   <include package="plomino.tinymce" />
   <include package="Products.CMFPlomino" />


### PR DESCRIPTION
Without this, it won't start on Plone4.1, because it doesn't know about the permission="cmf.ManagePortal".
See http://plone.org/documentation/manual/upgrade-guide/version/upgrading-plone-4.0-to-4.1/updating-add-on-products-for-plone-4.1/changing-dependencies-from-plone-to-products.cmfplone
